### PR TITLE
Pyproject; fixing LDFLAGS and intel-channel issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*~
+*.swp
+build
+*.egg-info

--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 ## Setup
 
+#### Using conda
 ```bash
-# Note: python3 required. For example:
-# conda create --prefix "./venv" python=3.7
-# conda activate ./venv
-conda install -c intel mkl mkl-include
-pip install nphil
+conda env create --prefix ./venv --file env.yaml
 ```
 
-The above steps have anecdotally failed due to a linker error (libmkl\_rt.so not found). If that happens, try the following:
+This will rely on the `nphil` dependency list to install `numpy`, `scikit`,
+and the likes.
+
+#### By cloning this directory
 
 ```bash
-conda install -c intel mkl mkl-include
-export LDFLAGS=-L/path/to/venv/lib
-export CPPFLAGS=-L/path/to/venv/include
+# Note: python3 required. For example:
+# conda create --prefix "./venv" python=3.10
+# conda activate ./venv
+conda install -c conda-forge mkl mkl-include
 git clone https://github.com/capoe/nphil.git
 cd nphil
 pip install .

--- a/env.yaml
+++ b/env.yaml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - mkl
+  - mkl-include
+  - pip
+  - pip:
+    - git+https://github.com/capoe/nphil.git#egg=nphil 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def make_cxx_extensions():
             'nphil._nphil',
             srcs,
             include_dirs=incdirs,
-            library_dirs=find_env_dir(dir_type="lib"),
+            library_dirs=[find_env_dir(dir_type="lib")],
             libraries=[],
             language='c++',
             extra_compile_args=cpp_extra_compile_args + ["-fvisibility=hidden"],

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ class get_pybind_include(object):
 def get_scripts():
     return [ "bin/philter" ]
 
-def find_env_include_dir():
+def find_env_dir(dir_type="include"):
     pydir = os.path.dirname(sys.executable)
-    incdir = os.path.join(pydir, "..", "include")
+    incdir = os.path.join(pydir, "..", dir_type)
     assert os.path.isdir(incdir)
     return incdir
 
@@ -25,7 +25,7 @@ def make_cxx_extensions():
     incdirs = [
         "./nphil/cxx",
         "./external",
-        find_env_include_dir(),
+        find_env_dir(dir_type="include"),
         get_pybind_include(),
         get_pybind_include(user=True)]
     cpp_extra_link_args = [
@@ -45,6 +45,7 @@ def make_cxx_extensions():
             'nphil._nphil',
             srcs,
             include_dirs=incdirs,
+            library_dirs=find_env_dir(dir_type="lib"),
             libraries=[],
             language='c++',
             extra_compile_args=cpp_extra_compile_args + ["-fvisibility=hidden"],


### PR DESCRIPTION
This should fix a few issues with the installing of the package. Namely:
- Migration to the newer standard using `pyproject.toml`
- Fixing the issues with LDFLAGS when linking `libmkl_rt.so`
- A recent issue with conda `intel` channel (switching to `conda-forge` completely for `libmkl`). For this see:
  - https://community.intel.com/t5/oneAPI-Registration-Download/Disappearance-of-intel-conda-channel/m-p/1614250#M2163
  - https://community.intel.com/t5/oneAPI-Registration-Download/Disappearance-of-intel-conda-channel-PART-2/m-p/1622324#M7973